### PR TITLE
Took inproper FEN strings out of history

### DIFF
--- a/frontend/src/components/Town/interactables/NewGameModal.tsx
+++ b/frontend/src/components/Town/interactables/NewGameModal.tsx
@@ -616,7 +616,7 @@ export default function NewGameModal(): JSX.Element {
                     onClick={loadHist}
                     style={{ display: 'block', fontSize: 14 }}>
                     {' '}
-                    {`${key}: ${history[key].split(' ')[0]}`}{' '}
+                    {`${key}`}{' '}
                   </button>
                 ))
               : ''


### PR DESCRIPTION
Gave an improper FEN string that the user can't actually load, since it was cut for sizing. This is removed as to not mislead the user.